### PR TITLE
fix add by url dialog by hiding incomplete cookie field

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -209,8 +209,9 @@
             <input type="text" id="dlgAddURL-url" class="tbox flr" />
             <label for="dlgAddURL-url">Torrent URL:</label>
           </div>
-          <div class="line-cont">
+          <div class="line-cont" style="display: none;">
             <div class="flr">
+              <label for="dlgAddURL-cookie">Cookies:</label>
               <input type="text" id="dlgAddURL-cookie" class="tbox" />
               <input
                 type="button"
@@ -219,7 +220,6 @@
                 value="Detect"
               />
             </div>
-            <label for="dlgAddURL-cookie">Cookies:</label>
           </div>
           <fieldset>
             <!-- TODO: Localize -->


### PR DESCRIPTION
from
![image](https://user-images.githubusercontent.com/59689/84646951-2154d280-af46-11ea-9ae5-ac6186385d40.png)

to
![image](https://user-images.githubusercontent.com/59689/84646979-2ade3a80-af46-11ea-97bc-ae0fabd3b655.png)
